### PR TITLE
upac now supports node > 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
   - "7"
   - "8"
   - "9"
+  - "10"
+  - "11"
+  - "12"
 cache:
   directories:
     - "node_modules"

--- a/package.json
+++ b/package.json
@@ -81,9 +81,6 @@
     "webpack-cli": "^2.0.15",
     "webpack-dev-server": "^2.11.1"
   },
-  "engines": {
-    "node": ">=6.0.0 <10"
-  },
   "jest": {
     "transform": {
       ".(ts)": "<rootDir>/node_modules/ts-jest/preprocessor.js"


### PR DESCRIPTION
Resolves: https://github.com/UD-UD/webpack-strip-log-loader/issues/2